### PR TITLE
Feature pause/resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0] - 2017-06-14
+### Added
+- `BehaviorContainer.prototype.pause(key:string) -> boolean`: pause an instance
+	- The `BehaviorContainer` can't process methods of a paused `'key'`
+	- `paused` method is called when a behavior instance is paused
+	- returns a boolean to indicate the success/fail
+- `BehaviorContainer.prototype.resume(key:string) -> boolean`: resume an paused instance
+	- `resumed` method is called when a behavior instance is paused
+	- returns a boolean to indicate the success/fail
+	- has a alias method named `unpause`
+
+### Changed
+- now using package `tap-spec` instead `tap-min`
+
 ## [1.0.2] - 2017-01-18
+
 ### Changed
 - updated `example.js`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.1.0] - 2017-06-14
+## [1.1.0] - 2017-06-15
 ### Added
 - `BehaviorContainer.prototype.pause(key:string) -> boolean`: pause an instance
 	- The `BehaviorContainer` can't process methods of a paused `'key'`
 	- `paused` method is called when a behavior instance is paused
-	- returns a boolean to indicate the success/fail
+	- returns a `boolean` to indicate the success/fail
 - `BehaviorContainer.prototype.resume(key:string) -> boolean`: resume an paused instance
 	- `resumed` method is called when a behavior instance is paused
-	- returns a boolean to indicate the success/fail
-	- has a alias method named `unpause`
+	- returns a `boolean` to indicate the success/fail
+- `BehaviorContainer.prototype.pauseAll()`: pause all instances of a container
+- `BehaviorContainer.prototype.resumeAll()`: resume all paused instances of a container
+- `BehaviorContainer.prototype.isPaused()`: returns a true if the instance is paused
 
 ### Changed
 - now using package `tap-spec` instead `tap-min`

--- a/lib/behavior-container.js
+++ b/lib/behavior-container.js
@@ -4,8 +4,16 @@ const removeByIndex = require('./helper/remove-by-index')
 
 function BehaviorContainer (gameObject, parent) {
   this.gameObject = gameObject
-  this._behaviorList = [] // store instances
-  this._behaviorMap = {} // use the 'key' to store the index of the instances
+
+  // store instances
+  this._behaviorList = []
+
+  // use the 'key' to store the index of the instances
+  this._behaviorMap = {}
+
+  // store paused instances
+  this._pausedBehaviors = {}
+
   this.parent = parent
 }
 
@@ -51,6 +59,9 @@ BehaviorContainer.prototype = {
     }
     removeByIndex(this._behaviorList, index)
 
+    // remove from paused list if necessary
+    this._pausedBehaviors[key] = NULL
+
     return true
   },
 
@@ -69,8 +80,54 @@ BehaviorContainer.prototype = {
     return this._behaviorMap[key] !== NULL
   },
 
+  pause (key) {
+    if (this.has(key) && !this.isPaused(key)) {
+      // process `paused` before pause the instance
+      this.process(key, 'paused')
+      this._pausedBehaviors[key] = true
+      return true
+    }
+    return false
+  },
+
+  pauseAll () {
+    const list = this._behaviorList
+    const len = list.length
+
+    if (len === 0) return
+
+    for(let i = 0; i < len; ++i) {
+      this.pause(list[i].options.$key)
+    }
+  },
+
+  resume (key) {
+    if (this.has(key) && this.isPaused(key)) {
+      this._pausedBehaviors[key] = NULL
+      // process `resumed` after resume the instance
+      this.process(key, 'resumed')
+      return true
+    }
+    return false
+  },
+
+  resumeAll () {
+    const list = this._behaviorList
+    const len = list.length
+
+    if (len === 0) return
+
+    for(let i = 0; i < len; ++i) {
+      this.resume(list[i].options.$key)
+    }
+  },
+
+  isPaused (key) {
+    return this._pausedBehaviors[key] !== NULL
+  },
+
   process (key, methodName, ...args) {
-    if (!this.has(key)) return
+    if (!this.has(key) || this.isPaused(key)) return
 
     const index = this._behaviorMap[key]
     const ref = this._behaviorList[index]
@@ -114,5 +171,11 @@ BehaviorContainer.prototype = {
   }
 
 }
+
+// alias for BehaviorContainer#resume
+BehaviorContainer.prototype.unpause = BehaviorContainer.prototype.resume
+
+// alias for BehaviorContainer#resumeAll
+BehaviorContainer.prototype.unpauseAll = BehaviorContainer.prototype.resumeAll
 
 module.exports = BehaviorContainer

--- a/lib/behavior-container.js
+++ b/lib/behavior-container.js
@@ -96,7 +96,7 @@ BehaviorContainer.prototype = {
 
     if (len === 0) return
 
-    for(let i = 0; i < len; ++i) {
+    for (let i = 0; i < len; ++i) {
       this.pause(list[i].options.$key)
     }
   },
@@ -117,7 +117,7 @@ BehaviorContainer.prototype = {
 
     if (len === 0) return
 
-    for(let i = 0; i < len; ++i) {
+    for (let i = 0; i < len; ++i) {
       this.resume(list[i].options.$key)
     }
   },
@@ -165,7 +165,7 @@ BehaviorContainer.prototype = {
 
     if (len === 0) return
 
-    for(let i = 0; i < len; ++i) {
+    for (let i = 0; i < len; ++i) {
       this.process(list[i].options.$key, methodName, ...args)
     }
   }

--- a/lib/behavior-container.js
+++ b/lib/behavior-container.js
@@ -1,4 +1,4 @@
-const NULL = undefined// never use "null"
+const NULL = undefined // never use "null"
 const extend = require('./helper/extend')
 const removeByIndex = require('./helper/remove-by-index')
 
@@ -171,11 +171,5 @@ BehaviorContainer.prototype = {
   }
 
 }
-
-// alias for BehaviorContainer#resume
-BehaviorContainer.prototype.unpause = BehaviorContainer.prototype.resume
-
-// alias for BehaviorContainer#resumeAll
-BehaviorContainer.prototype.unpauseAll = BehaviorContainer.prototype.resumeAll
 
 module.exports = BehaviorContainer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "behavior-system",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A behavior system for javascript games inspired by Construct 2",
   "main": "lib/behavior-system.js",
   "author": "Luiz Bills",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/luizbills/behavior-system/issues"
   },
   "scripts": {
-    "test": "tape test/**/*.js | tap-min",
+    "test": "tape test/**/*.js | tap-spec",
     "lint": "standard lib/**/* test/**/*",
     "build": "browserify lib/behavior-system.js -t es2040 -s BehaviorSystem -o dist/behavior-system.js",
     "min": "uglifyjs dist/behavior-system.js -c -m -o dist/behavior-system.min.js",
@@ -34,7 +34,7 @@
     "browserify": "^13.0.0",
     "es2040": "^1.2.4",
     "standard": "^6.0.8",
-    "tap-min": "^1.1.0",
+    "tap-spec": "^4.1.1",
     "tape": "^4.5.1",
     "uglify-js": "^2.6.2"
   },
@@ -44,6 +44,6 @@
     "dist/"
   ],
   "engines": {
-    "node" : ">=6.x"
+    "node": ">=6.x"
   }
 }

--- a/test/behavior-container.js
+++ b/test/behavior-container.js
@@ -229,16 +229,11 @@ test('BehaviorContainer#resume', function (assert) {
   }
   container.set('b', Behavior)
   container.pause('b')
-  container.unpause('b')
   container.resume('b')
-  container.unpause('b')
+  container.resume('b')
   actual = obj.x
   expected = 10
   assert.equal(actual, expected, 'should not call the method `resumed` (if exists) again of a already resumed behavior instance')
-
-  actual = BehaviorContainer.prototype.unpause
-  expected = BehaviorContainer.prototype.resume
-  assert.equal(actual, expected, 'should has a alias named `unpause`')
 
   assert.end()
 })
@@ -281,10 +276,6 @@ test('BehaviorContainer#pauseAll', function (assert) {
   actual = !container.isPaused('b1') && !container.isPaused('b2')
   expected = true
   assert.equal(actual, expected, 'should resume/unpause all behavior instance of the instance')
-
-  actual = BehaviorContainer.prototype.unpauseAll
-  expected = BehaviorContainer.prototype.resumeAll
-  assert.equal(actual, expected, 'should has a alias named `unpauseAll`')
 
   assert.end()
 })

--- a/test/behavior-container.js
+++ b/test/behavior-container.js
@@ -147,6 +147,177 @@ test('BehaviorContainer#has', function (assert) {
   assert.end()
 })
 
+test('BehaviorContainer#pause', function (assert) {
+  let actual,
+    expected,
+    obj,
+    container,
+    Behavior
+
+  obj = {
+    x: 10
+  }
+  container = new BehaviorContainer(obj)
+  Behavior = {
+    change: (obj) => (obj.x = 20)
+  }
+  container.set('b', Behavior)
+  container.pause('b')
+  container.process('b', 'change')
+  actual = obj.x
+  expected = 10
+  assert.equal(actual, expected, 'should not process/call methods of a paused behavior instance')
+
+  obj = {
+    x: 0
+  }
+  container = new BehaviorContainer(obj)
+  Behavior = {
+    paused: (obj) => (obj.x = 10)
+  }
+  container.set('b', Behavior)
+  container.pause('b')
+  actual = obj.x
+  expected = 10
+  assert.equal(actual, expected, 'should call the method `paused` (if exists) of the paused behavior instance')
+
+  obj = {
+    x: 0
+  }
+  container = new BehaviorContainer(obj)
+  Behavior = {
+    paused: (obj) => (obj.x += 10)
+  }
+  container.set('b', Behavior)
+  container.pause('b')
+  container.pause('b')
+  container.pause('b')
+  actual = obj.x
+  expected = 10
+  assert.equal(actual, expected, 'should not call the method `paused` (if exists) again of a already paused behavior instance')
+
+  assert.end()
+})
+
+test('BehaviorContainer#resume', function (assert) {
+  let actual,
+    expected,
+    obj,
+    container,
+    Behavior
+
+  obj = {
+    x: 0
+  }
+  container = new BehaviorContainer(obj)
+  Behavior = {
+    resumed: (obj) => (obj.x = 10)
+  }
+  container.set('b', Behavior)
+  container.pause('b')
+  container.resume('b')
+  actual = obj.x
+  expected = 10
+  assert.equal(actual, expected, 'should call the method `resumed` (if exists) of the resumed behavior instance')
+
+  obj = {
+    x: 0
+  }
+  container = new BehaviorContainer(obj)
+  Behavior = {
+    resumed: (obj) => (obj.x += 10)
+  }
+  container.set('b', Behavior)
+  container.pause('b')
+  container.unpause('b')
+  container.resume('b')
+  container.unpause('b')
+  actual = obj.x
+  expected = 10
+  assert.equal(actual, expected, 'should not call the method `resumed` (if exists) again of a already resumed behavior instance')
+
+  actual = BehaviorContainer.prototype.unpause
+  expected = BehaviorContainer.prototype.resume
+  assert.equal(actual, expected, 'should has a alias named `unpause`')
+
+  assert.end()
+})
+
+test('BehaviorContainer#pauseAll', function (assert) {
+  let actual,
+    expected,
+    obj,
+    container,
+    Behavior
+
+  obj = {}
+  container = new BehaviorContainer(obj)
+  Behavior = {}
+  container.set('b1', Behavior)
+  container.set('b2', Behavior)
+  container.pauseAll()
+  actual = container.isPaused('b1') && container.isPaused('b2')
+  expected = true
+  assert.equal(actual, expected, 'should pause all behavior instance of the instance')
+
+  assert.end()
+})
+
+test('BehaviorContainer#pauseAll', function (assert) {
+  let actual,
+    expected,
+    obj,
+    container,
+    Behavior
+
+  obj = {}
+  container = new BehaviorContainer(obj)
+  Behavior = {}
+  container.set('b1', Behavior)
+  container.set('b2', Behavior)
+  container.pause('b1')
+  container.pause('b2')
+  container.resumeAll()
+  actual = !container.isPaused('b1') && !container.isPaused('b2')
+  expected = true
+  assert.equal(actual, expected, 'should resume/unpause all behavior instance of the instance')
+
+  actual = BehaviorContainer.prototype.unpauseAll
+  expected = BehaviorContainer.prototype.resumeAll
+  assert.equal(actual, expected, 'should has a alias named `unpauseAll`')
+
+  assert.end()
+})
+
+test('BehaviorContainer#isPause', function (assert) {
+  let actual,
+    expected,
+    obj,
+    container,
+    Behavior
+
+  obj = {}
+  container = new BehaviorContainer(obj)
+  Behavior = {}
+  container.set('b', Behavior)
+  container.pause('b')
+  actual = container.isPaused('b')
+  expected = true
+  assert.equal(actual, expected, 'should returns true when the key is paused')
+
+  obj = {}
+  container = new BehaviorContainer(obj)
+  Behavior = {}
+  container.set('bb', Behavior)
+  actual = container.isPaused('bb')
+  container.pause('b')
+  container.resume('b')
+  expected = false
+  assert.equal(actual, expected, 'should returns false when the key is not paused')
+
+  assert.end()
+})
+
 test('BehaviorContainer#process', function (assert) {
   let actual,
     expected,


### PR DESCRIPTION
# New `BehaviorContainer` methods

- `.pause(key)`
- `.resume(key)` (alias: `.unpause`)
- `.pauseAll()`
- `.resumeAll()` (alias: `.unpauseAll`)
- `.isPaused(key)`

## Tests

100% working

## Notes

- the `BehaviorContainer` can't process methods of a paused `"key"`
- the `paused` method (if exists) is called when a behavior instance is paused (only once)
- the `resumed` method (if exists) is called when a behavior instance is resumed/unpaused (only once)
- `.pause` and `.resume` returns a boolean to indicate the success/fail